### PR TITLE
OCR gosseract support (see #16)

### DIFF
--- a/docconv.go
+++ b/docconv.go
@@ -36,6 +36,14 @@ func MimeTypeByExtension(filename string) string {
 		return "text/xml"
 	case ".xhtml", ".html", ".htm":
 		return "text/html"
+	case ".jpg", ".jpeg", ".jpe", ".jfif", ".jfif-tbnl":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".tif":
+		return "image/tif"
+	case ".tiff":
+		return "image/tiff"
 	case ".txt":
 		return "text/plain"
 	}

--- a/docconv.go
+++ b/docconv.go
@@ -86,6 +86,9 @@ func Convert(r io.Reader, mimeType string, readability bool) (*Response, error) 
 	case "text/xml", "application/xml":
 		body, meta, err = ConvertXML(r)
 
+	case "image/jpeg", "image/png", "image/tif", "image/tiff":
+		body, meta, err = ConvertImage(r)
+
 	case "text/plain":
 		var b []byte
 		b, err = ioutil.ReadAll(r)

--- a/image.go
+++ b/image.go
@@ -1,0 +1,12 @@
+// build !ocr
+
+package docconv
+
+import (
+	"fmt"
+	"io"
+)
+
+func ConvertImage(r io.Reader) (string, map[string]string, error) {
+	return "", nil, fmt.Errorf("docconv not built with `ocr` build tag")
+}

--- a/image_ocr.go
+++ b/image_ocr.go
@@ -1,3 +1,5 @@
+// +build ocr
+
 package docconv
 
 import (

--- a/images.go
+++ b/images.go
@@ -1,0 +1,25 @@
+package docconv
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/otiai10/gosseract"
+)
+
+func ConvertImage(r io.Reader) (string, map[string]string, error) {
+	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	if err != nil {
+		return "", nil, fmt.Errorf("error creating local file: %v", err)
+	}
+	defer f.Done()
+
+	meta := make(map[string]string)
+	out := make(chan string, 1)
+	go func(file *LocalFile) {
+		body := gosseract.Must(gosseract.Params{Src: file.Name()})
+		out <- string(body)
+	}(f)
+
+	return <-out, meta, nil
+}


### PR DESCRIPTION
This is a modification of #16 which doesn't include the gosseract dependency by default.

To build docconv with OCR support, follow the installation instructions for https://github.com/otiai10/gosseract, and then:

    $ go get -tags ocr github.com/sajari/docconv/...

Or

    $ cd $GOPATH/src/github.com/sajari/docconv/docconv
    $ go build -tags ocr 

@marioidival Can you confirm that this works for you?