### PR TITLE
Make compatible with uppercase file extensions

### DIFF
--- a/docconv.go
+++ b/docconv.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -19,7 +20,7 @@ type Response struct {
 
 // Determine the mime type by the file's extension
 func MimeTypeByExtension(filename string) string {
-	switch path.Ext(filename) {
+	switch strings.ToLower(path.Ext(filename)) {
 	case ".doc":
 		return "application/msword"
 	case ".docx":


### PR DESCRIPTION
Some of our PDFs come through with a capitalized ".PDF" extension and the file type wasn't being recognized when converting from the command line. Made a change to downcase the file extension when checking it in MimeTypeByExtension.