### PR TITLE
Add HTMLReadability version that works with appengine

### DIFF
--- a/html.go
+++ b/html.go
@@ -108,7 +108,7 @@ func cleanHTML(r io.Reader, all bool) string {
 	}
 }
 
-// HTMLReadabilityOptions is a type which defines parameters that are passed to the justext paackage.
+// HTMLReadabilityOptions is a type which defines parameters that are passed to the justext package.
 // TODO: Improve this!
 type HTMLReadabilityOptions struct {
 	LengthLow             int

--- a/html.go
+++ b/html.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package docconv
 
 import (

--- a/html_appengine.go
+++ b/html_appengine.go
@@ -1,0 +1,18 @@
+// +build appengine
+
+package docconv
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+)
+
+func HTMLReadability(r io.Reader) []byte {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		log.Printf("HTMLReadability: %v", err)
+		return nil
+	}
+	return b
+}


### PR DESCRIPTION
See https://github.com/JalfResi/justext/issues/30 - can't use that import for appengine standard because of the `unsafe` import.