### PR TITLE
client: flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/sajari/docconv/client"
+	"github.com/sajari/docconv"
 )
 
 func main() {
 	// Create a new client, using the default endpoint (localhost:8888)
-	c := client.New()
+	c := docconv.NewClient()
 
-	res, err := client.ConvertPath(c, "your-file.pdf")
+	res, err := c.ConvertPath("your-file.pdf")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -1,6 +1,4 @@
-// Package client defines types and functions for interacting with
-// docconv HTTP servers.
-package client
+package docconv
 
 import (
 	"bytes"
@@ -50,9 +48,9 @@ func WithProtocol(protocol string) Opt {
 	}
 }
 
-// New creates a new docconv client for interacting with a docconv HTTP
+// NewClient creates a new docconv client for interacting with a docconv HTTP
 // server.
-func New(opts ...Opt) *Client {
+func NewClient(opts ...Opt) *Client {
 	c := &Client{
 		endpoint:   DefaultEndpoint,
 		protocol:   DefaultProtocol,
@@ -70,14 +68,6 @@ type Client struct {
 	endpoint   string
 	protocol   string
 	httpClient *http.Client
-}
-
-// Response is from docconv.Response copied here to avoid dependency on
-// the docconv package.
-type Response struct {
-	Body  string            `json:"body"`
-	Meta  map[string]string `json:"meta"`
-	MSecs uint32            `json:"msecs"`
 }
 
 // Convert a file from a local path using the http client
@@ -116,7 +106,7 @@ func (c *Client) Convert(r io.Reader, filename string) (*Response, error) {
 
 // ConvertPath uses the docconv Client to convert the local file
 // found at path.
-func ConvertPath(c *Client, path string) (*Response, error) {
+func (c *Client) ConvertPath(path string) (*Response, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@dhowden can we flatten the client back out now that the `html_appengine.go` file has been added?

Reason: so we don't have to import the client as `docconv "github.com/sajari/docconv/client"`. If I'm not mistaken, I'm guessing that you put this into a `client` package because this wasn't compiling in GAE due to the dependency on `justext` which uses `unsafe`.

If we do this, might be worth tagging the current release before doing so.

Open for discussion...