### PR TITLE
Updated the gosseract path dependency

### DIFF
--- a/image_ocr.go
+++ b/image_ocr.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/otiai10/gosseract/v1/gosseract"
+	"github.com/otiai10/gosseract"
 )
 
 var langs = struct {


### PR DESCRIPTION
The dependency path changed in the gosseract project, so it didn't allowed to compile with:

go get -tags ocr code.sajari.com/docconv/...

package github.com/otiai10/gosseract/v1/gosseract: cannot find package "github.com/otiai10/gosseract/v1/gosseract" in any of: