### PR TITLE
Update version of gosseract dependency

### DIFF
--- a/image_ocr.go
+++ b/image_ocr.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/otiai10/gosseract/v1/gosseract"
+	"github.com/otiai10/gosseract/v2"
 )
 
 var langs = struct {


### PR DESCRIPTION
Using go modules, fixing:
github.com/otiai10/gosseract/v1/gosseract: module github.com/otiai10/gosseract@latest found (v2.2.1+incompatible), but does not contain package github.com/otiai10/gosseract/v1/gosseract