### PR TITLE
Multiplatform os.TempDir instead of /tmp

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,7 @@ import (
 
 // ConvertDoc converts an MS Word .doc to text.
 func ConvertDoc(r io.Reader) (string, map[string]string, error) {
-	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	f, err := NewLocalFile(r, os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating local file: %v", err)
 	}
@@ -57,7 +57,7 @@ func ConvertDoc(r io.Reader) (string, map[string]string, error) {
 	go func() {
 
 		// Save output to a file
-		outputFile, err := ioutil.TempFile("/tmp", "sajari-convert-")
+		outputFile, err := ioutil.TempFile(os.TempDir(), "sajari-convert-")
 		if err != nil {
 			// TODO: Remove this.
 			log.Println("TempFile Out:", err)

--- a/image_ocr.go
+++ b/image_ocr.go
@@ -5,6 +5,7 @@ package docconv
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/otiai10/gosseract/v1/gosseract"
@@ -18,7 +19,7 @@ var langs = struct {
 // ConvertImage converts images to text.
 // Requires gosseract.
 func ConvertImage(r io.Reader) (string, map[string]string, error) {
-	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	f, err := NewLocalFile(r, os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating local file: %v", err)
 	}

--- a/pdf.go
+++ b/pdf.go
@@ -5,11 +5,12 @@ package docconv
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 func ConvertPDF(r io.Reader) (string, map[string]string, error) {
 
-	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	f, err := NewLocalFile(r, os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating local file: %v", err)
 	}

--- a/pdf_ocr.go
+++ b/pdf_ocr.go
@@ -37,7 +37,7 @@ func cleanupTemp(tmpDir string) {
 func ConvertPDFImages(path string) (BodyResult, error) {
 	bodyResult := BodyResult{}
 
-	tmp, err := ioutil.TempDir("/tmp", "tmp-imgs-")
+	tmp, err := ioutil.TempDir(os.TempDir(), "tmp-imgs-")
 	if err != nil {
 		bodyResult.err = err
 		return bodyResult, err
@@ -123,7 +123,7 @@ func PDFHasImage(path string) bool {
 }
 
 func ConvertPDF(r io.Reader) (string, map[string]string, error) {
-	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	f, err := NewLocalFile(r, os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating local file: %v", err)
 	}

--- a/rtf.go
+++ b/rtf.go
@@ -3,6 +3,7 @@ package docconv
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -10,7 +11,7 @@ import (
 
 // ConvertRTF converts RTF files to text.
 func ConvertRTF(r io.Reader) (string, map[string]string, error) {
-	f, err := NewLocalFile(r, "/tmp", "sajari-convert-")
+	f, err := NewLocalFile(r, os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating local file: %v", err)
 	}

--- a/tidy.go
+++ b/tidy.go
@@ -11,7 +11,7 @@ import (
 // Errors & warnings are deliberately suppressed as underlying tools
 // throw warnings very easily.
 func Tidy(r io.Reader, xmlIn bool) ([]byte, error) {
-	f, err := ioutil.TempFile("/tmp", "sajari-convert-")
+	f, err := ioutil.TempFile(os.TempDir(), "sajari-convert-")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
/tmp does not work on Windows (when there is no c:\tmp directory by someone already created). It'd be better to use os.TempDir() function to get a directory for tempfiles.