### PR TITLE
enable html output when readability is set to true

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt install unrtf
+        run: sudo apt install unrtf tidy
 
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v2

--- a/html.go
+++ b/html.go
@@ -124,9 +124,7 @@ type HTMLReadabilityOptions struct {
 
 // HTMLReadabilityOptionsValues are the global settings used for HTMLReadability.
 // TODO: Remove this from global state.
-var HTMLReadabilityOptionsValues HTMLReadabilityOptions = HTMLReadabilityOptions{
-	ReadabilityUseClasses: "good",
-}
+var HTMLReadabilityOptionsValues HTMLReadabilityOptions
 
 // HTMLReadability extracts the readable text in an HTML document
 func HTMLReadability(r io.Reader) []byte {

--- a/html.go
+++ b/html.go
@@ -124,7 +124,9 @@ type HTMLReadabilityOptions struct {
 
 // HTMLReadabilityOptionsValues are the global settings used for HTMLReadability.
 // TODO: Remove this from global state.
-var HTMLReadabilityOptionsValues HTMLReadabilityOptions
+var HTMLReadabilityOptionsValues HTMLReadabilityOptions = HTMLReadabilityOptions{
+	ReadabilityUseClasses: "good",
+}
 
 // HTMLReadability extracts the readable text in an HTML document
 func HTMLReadability(r io.Reader) []byte {

--- a/html_test/html_test.go
+++ b/html_test/html_test.go
@@ -1,0 +1,37 @@
+package html_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"code.sajari.com/docconv"
+)
+
+func TestConvertHTML(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/test.html")
+	if err != nil {
+		t.Fatalf("got error %v, want nil", err)
+	}
+	res, _, err := docconv.ConvertHTML(bytes.NewReader(data), true)
+	if err != nil {
+		t.Fatalf("got error %v, want nil", err)
+	}
+	lines := strings.Split(res, "\n")
+	for _, i := range lines {
+		t.Log(i)
+	}
+	line, expectedLine := lines[0], "1"
+	if line != expectedLine {
+		t.Fatalf("got %s, want %s", line, expectedLine)
+	}
+	line, expectedLine = lines[1], "word"
+	if line != expectedLine {
+		t.Fatalf("got %s, want %s", line, expectedLine)
+	}
+	line, expectedLine = lines[2], "This is a full sentence."
+	if line != expectedLine {
+		t.Fatalf("got %s, want %s", line, expectedLine)
+	}
+}

--- a/html_test/html_test.go
+++ b/html_test/html_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestConvertHTML(t *testing.T) {
+
+	// enable output with readability: true
+	docconv.HTMLReadabilityOptionsValues.ReadabilityUseClasses = "good"
+
 	data, err := ioutil.ReadFile("testdata/test.html")
 	if err != nil {
 		t.Fatalf("got error %v, want nil", err)

--- a/html_test/testdata/test.html
+++ b/html_test/testdata/test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+	<title></title>
+	<meta name="created" content="2021-03-29T11:30:00"/>
+	<meta name="changed" content="2021-03-29T11:31:00"/>
+	<style type="text/css">
+		@page { size: 8.27in 11.69in; margin: 0.79in }
+		p { margin-bottom: 0.1in; direction: ltr; color: #000000; line-height: 115%; orphans: 2; widows: 2; background: transparent }
+	</style>
+</head>
+<body lang="en-US" text="#000000" link="#000080" vlink="#800000" dir="ltr"><p class="western" align="left" style="margin-bottom: 0in; line-height: 100%">
+1</p>
+<p>word</p>
+<p>This is a full sentence.</p>
+</body>
+</html>


### PR DESCRIPTION
If html.go > `HTMLReadabilityOptionsValues.ReadabilityUseClasses` is left as an empty string as initialized, nothing will be included in the output. `"good"` is probably the very minimum that should be included in the output.