### PR TITLE
actions: stop building for Go 1.13

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.15", "1.14", "1.13"]
+        go: ["1.16", "1.15", "1.14"]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We want to use testing.Cleanup which was added in 1.14.