### PR TITLE
xml: support also files not encoded in utf-8

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -5,6 +5,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+
+	"golang.org/x/net/html/charset"
 )
 
 // ConvertXML converts an XML file to text.
@@ -27,6 +29,7 @@ func XMLToText(r io.Reader, breaks []string, skip []string, strict bool) (string
 
 	dec := xml.NewDecoder(r)
 	dec.Strict = strict
+	dec.CharsetReader = charset.NewReaderLabel
 	for {
 		t, err := dec.Token()
 		if err != nil {


### PR DESCRIPTION
Hi,

when xml is not encoded in utf-8, decoder requires charset reader.

Credits: https://stackoverflow.com/questions/6002619/unmarshal-an-iso-8859-1-xml-input-in-go/32224438#32224438