### PR TITLE
fix: case insensitive processing of docx and pptx internals

### DIFF
--- a/docx.go
+++ b/docx.go
@@ -55,7 +55,7 @@ func ConvertDocx(r io.Reader) (string, map[string]string, error) {
 
 	zipFiles := mapZipFiles(zr.File)
 
-	contentTypeDefinition, err := getContentTypeDefinition(zipFiles["[Content_Types].xml"])
+	contentTypeDefinition, err := getContentTypeDefinition(zipFiles["[content_types].xml"])
 	if err != nil {
 		return "", nil, err
 	}
@@ -63,7 +63,7 @@ func ConvertDocx(r io.Reader) (string, map[string]string, error) {
 	meta := make(map[string]string)
 	var textHeader, textBody, textFooter string
 	for _, override := range contentTypeDefinition.Overrides {
-		f := zipFiles[override.PartName]
+		f := zipFiles[strings.ToLower(override.PartName)]
 
 		switch {
 		case override.ContentType == "application/vnd.openxmlformats-package.core-properties+xml":
@@ -129,8 +129,9 @@ func getContentTypeDefinition(zf *zip.File) (*contentTypeDefinition, error) {
 func mapZipFiles(files []*zip.File) map[string]*zip.File {
 	filesMap := make(map[string]*zip.File, 2*len(files))
 	for _, f := range files {
-		filesMap[f.Name] = f
-		filesMap["/"+f.Name] = f
+		lName := strings.ToLower(f.Name)
+		filesMap[lName] = f
+		filesMap["/"+lName] = f
 	}
 	return filesMap
 }

--- a/pptx.go
+++ b/pptx.go
@@ -43,7 +43,7 @@ func ConvertPptx(r io.Reader) (string, map[string]string, error) {
 
 	zipFiles := mapZipFiles(zr.File)
 
-	contentTypeDefinition, err := getContentTypeDefinition(zipFiles["[Content_Types].xml"])
+	contentTypeDefinition, err := getContentTypeDefinition(zipFiles["[content_types].xml"])
 	if err != nil {
 		return "", nil, err
 	}
@@ -51,7 +51,7 @@ func ConvertPptx(r io.Reader) (string, map[string]string, error) {
 	meta := make(map[string]string)
 	var textBody string
 	for _, override := range contentTypeDefinition.Overrides {
-		f := zipFiles[override.PartName]
+		f := zipFiles[strings.ToLower(override.PartName)]
 
 		switch override.ContentType {
 		case "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",


### PR DESCRIPTION
Hi,

Sometimes, the case in Content-Types.xml and zipped file names do not match. Maybe not an issue on Windows, but is is an issue, when such file is searched in map with file names. (In particular, there was a directory dosProps, but in xml Overrides was docprops).

I've changed the processing to be case insensitive.

Regards