### PR TITLE
Fix mime type of .tif files

### DIFF
--- a/docconv.go
+++ b/docconv.go
@@ -46,7 +46,7 @@ func MimeTypeByExtension(filename string) string {
 	case ".png":
 		return "image/png"
 	case ".tif":
-		return "image/tif"
+		fallthrough
 	case ".tiff":
 		return "image/tiff"
 	case ".txt":
@@ -93,7 +93,7 @@ func Convert(r io.Reader, mimeType string, readability bool) (*Response, error) 
 	case "text/xml", "application/xml":
 		body, meta, err = ConvertXML(r)
 
-	case "image/jpeg", "image/png", "image/tif", "image/tiff":
+	case "image/jpeg", "image/png", "image/tiff":
 		body, meta, err = ConvertImage(r)
 
 	case "text/plain":


### PR DESCRIPTION
`.tif` files should map to the `image/tiff` mime type.

List of official mime types:
https://www.iana.org/assignments/media-types/media-types.xhtml

From MDN web docs:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types