### PR TITLE
use as the default "good" and "neargood" for html when ReadabilityUseClasses is empty

### DIFF
--- a/html.go
+++ b/html.go
@@ -145,7 +145,12 @@ func HTMLReadability(r io.Reader) []byte {
 		return nil
 	}
 
-	useClasses := strings.SplitN(HTMLReadabilityOptionsValues.ReadabilityUseClasses, ",", 10)
+	var useClasses []string
+	if HTMLReadabilityOptionsValues.ReadabilityUseClasses == "" {
+		useClasses = []string{"good", "neargood"}
+	} else {
+		useClasses = strings.SplitN(HTMLReadabilityOptionsValues.ReadabilityUseClasses, ",", 10)
+	}
 
 	output := ""
 	for _, paragraph := range paragraphSet {


### PR DESCRIPTION
That are the defaults for docd, but that doesn't apply to library usage
generating the problem seen in the issue #78.

This PR can have a drawback if you intentionally pass an empty list for
readabilityUseClasses, but that makes no sense, because the resulting
extraction would be an empty body.

Fixes #78