### PR TITLE
docd: bump to Go 1.21 and debian:12

### DIFF
--- a/docd/Dockerfile
+++ b/docd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build
+FROM golang:1.21 AS build
 
 WORKDIR /app
 COPY . ./
@@ -6,7 +6,7 @@ RUN go build -o /bin/docd ./docd
 
 ################################################################################
 
-FROM debian:11-slim AS docd
+FROM debian:12-slim AS docd
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docd/main.go
+++ b/docd/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime"
 
 	"cloud.google.com/go/errorreporting"
 
@@ -92,6 +93,7 @@ func serve(er internal.ErrorReporter, cs *convertServer) {
 	r.HandleFunc("/convert", cs.convert)
 
 	// Start webserver
+	log.Println("Go version", runtime.Version())
 	log.Println("Setting log level to", *logLevel)
 	log.Println("Starting docconv on", *listenAddr)
 	log.Fatal(http.ListenAndServe(*listenAddr, internal.RecoveryHandler(er)(r)))


### PR DESCRIPTION
Also show Go version in startup logs.