### PR TITLE
Use the latest upstream richardlehane/msoleps dependency instead of a fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/otiai10/gosseract/v2 v2.2.4
 	github.com/richardlehane/mscfb v1.0.3
-	github.com/richardlehane/msoleps v1.0.3
+	github.com/richardlehane/msoleps v1.0.4-0.20231124170528-c8ca5a164365
 	golang.org/x/net v0.17.0
 	google.golang.org/protobuf v1.30.0
 )
@@ -44,5 +44,3 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.56.3 // indirect
 )
-
-replace github.com/richardlehane/msoleps v1.0.3 => github.com/sajari/msoleps v0.0.0-20231120031048-d0092b82abea

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/richardlehane/mscfb v1.0.3 h1:rD8TBkYWkObWO0oLDFCbwMeZ4KoalxQy+QgniCj3nKI=
 github.com/richardlehane/mscfb v1.0.3/go.mod h1:YzVpcZg9czvAuhk9T+a3avCpcFPMUWm7gK3DypaEsUk=
 github.com/richardlehane/msoleps v1.0.1/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
-github.com/sajari/msoleps v0.0.0-20231120031048-d0092b82abea h1:DUw6mwTMJDj99FJmlcjSPiOPJWL0DM0IV7T1JCXDc+s=
-github.com/sajari/msoleps v0.0.0-20231120031048-d0092b82abea/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
+github.com/richardlehane/msoleps v1.0.4-0.20231124170528-c8ca5a164365 h1:x5G1rZBYckUdhRTXyd8u0C1WT/oGWT99HFPYdOJ+Qyc=
+github.com/richardlehane/msoleps v1.0.4-0.20231124170528-c8ca5a164365/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
 github.com/simplereach/timeutils v1.2.0/go.mod h1:VVbQDfN/FHRZa1LSqcwo4kNZ62OOyqLLGQKYB3pB0Q8=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cmavspvIl9nulOYwdy6IFRRo=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=


### PR DESCRIPTION
The replace directive dependency ([here](https://github.com/sajari/docconv/blob/6e3f8759fa344f827f83b5ce1f06290b0164cd46/go.mod#L48)) causes `go install` to fail:
```sh
go install code.sajari.com/docconv/v2/docd@latest
```

```text
go: code.sajari.com/docconv/v2/docd@latest (in code.sajari.com/docconv/v2@v2.0.0-pre.4):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

> Further more, the referenced commit in the replace directive dependency does not belong to any branch (https://github.com/sajari/msoleps/commit/d0092b82abea), probably because the branch was deleted after a successful PR.

As the temporary fork fix is merged into upstream (see [here](https://github.com/sajari/docconv/pull/156)), revert to using the latest version of that.